### PR TITLE
Bugfix, invalid isoformat string

### DIFF
--- a/src/purei9_unofficial/cloudv2.py
+++ b/src/purei9_unofficial/cloudv2.py
@@ -167,7 +167,7 @@ class CloudRobot(AbstractRobot, CachedData):
         r = do_http("GET", self.cloudclient.apiurl + "/robots/" + self.id + "/history", headers=self.cloudclient._getHeaders())
         
         return list(map(lambda item: CleaningSession(
-                endtime=datetime.datetime.fromisoformat(item["timeStamp"]), 
+                endtime=datetime.datetime.strptime(item["timeStamp"], "%Y-%m-%dT%H:%M:%S.%f"), 
                 duration=item["cleaningSession"]["cleaningDuration"] / 10000000.0 if "cleaningSession" in item else None, 
                 cleandearea=item["cleanedArea"], 
                 #endstatus=item["cleaningSession"]["completion"]


### PR DESCRIPTION
When attempting to use `getCleaningSessions()` I get this error:

<img width="639" alt="bug in cleaning sessions" src="https://user-images.githubusercontent.com/1544220/209169224-17c82ec9-350d-4a5e-b3d3-cae9038ebdc0.png">

Home Assistant is using an older version of Python that cannot parse the date time as an ISO format. I've verified by running `docker run --rm -it --entrypoint bash python:3.10` and executed the following script:

```python
from datetime import datetime

print(datetime.fromisoformat("2021-09-15T18:49:22.14")
```

Instead, this worked:

```python
from datetime import datetime

print(datetime.strptime("2021-09-15T18:49:22.14", "%Y-%m-%dT%H:%M:%S.%f"))
```