### PR TITLE
Add check so that map zones are not None, as they can be if map lacks zones

### DIFF
--- a/src/purei9_unofficial/cloudv3.py
+++ b/src/purei9_unofficial/cloudv3.py
@@ -297,8 +297,8 @@ class CloudMap:
             self.name = js["name"]
         else:
             self.name = None
-        
-        if "zones" in js:
+
+        if "zones" in js and js["zones"] is not None:
             self.zones = list(map(lambda x: CloudZone(self, x), js["zones"]))
         else:
             self.zones = []


### PR DESCRIPTION
Should solve #30 since the issue seems to be js["zones"] being None, but zones still existing in js, so the check on row 301 failed to check for this edge-case. 